### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type": "MIT",
     "url": "https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE"
   },
+  "scripts": {
+    "start": "gulp",
+    "test": "gulp dev"
+  },
   "devDependencies": {
     "bootstrap": "^3.3.7",
     "browser-sync": "^2.13.0",


### PR DESCRIPTION
- added ability to use `npm start` for default `gulp` task, and `npm test` for `gulp dev` task

Not sure if PR's are being accepted, but this is just a helper idea.
